### PR TITLE
allow Double condition for Double and Long.

### DIFF
--- a/src/main/java/org/embulk/filter/row/ConditionFactory.java
+++ b/src/main/java/org/embulk/filter/row/ConditionFactory.java
@@ -2,6 +2,7 @@ package org.embulk.filter.row;
 
 import com.google.common.base.Throwables;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.embulk.config.ConfigException;
 import org.embulk.spi.Column;
 import org.embulk.spi.time.Timestamp;
@@ -13,7 +14,6 @@ import org.embulk.spi.type.LongType;
 import org.embulk.spi.type.StringType;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
-
 import org.joda.time.DateTimeZone;
 import org.jruby.embed.ScriptingContainer;
 
@@ -101,7 +101,7 @@ public class ConditionFactory
         else if (!conditionConfig.getArgument().isPresent()) {
             throw new ConfigException(String.format("RowFilterPlugin: Argument is missing on column: %s", columnName));
         }
-        else if (conditionConfig.getArgument().get() instanceof Number) {
+        else if (NumberUtils.isNumber(conditionConfig.getArgument().get().toString())) {
             Double argument = new Double(conditionConfig.getArgument().get().toString());
             return new DoubleCondition(operator, argument, not);
         }

--- a/src/main/java/org/embulk/filter/row/ConditionFactory.java
+++ b/src/main/java/org/embulk/filter/row/ConditionFactory.java
@@ -84,8 +84,8 @@ public class ConditionFactory
         else if (!conditionConfig.getArgument().isPresent()) {
             throw new ConfigException(String.format("RowFilterPlugin: Argument is missing on column: %s", columnName));
         }
-        else if (conditionConfig.getArgument().get() instanceof Number) {
-            Long argument = new Long(conditionConfig.getArgument().get().toString()).longValue();
+        else if (NumberUtils.isNumber(conditionConfig.getArgument().get().toString())) {
+            Double argument = new Double(conditionConfig.getArgument().get().toString());
             return new LongCondition(operator, argument, not);
         }
         else {

--- a/src/main/java/org/embulk/filter/row/LongCondition.java
+++ b/src/main/java/org/embulk/filter/row/LongCondition.java
@@ -1,5 +1,6 @@
 package org.embulk.filter.row;
 
+
 public class LongCondition implements Condition
 {
     private LongComparator comparator;
@@ -10,7 +11,7 @@ public class LongCondition implements Condition
         boolean compare(Long subject);
     }
 
-    public LongCondition(final String operator, final Long argument, final boolean not)
+    public LongCondition(final String operator, final Double argument, final boolean not)
     {
         final LongComparator comparator;
         switch (operator.toUpperCase()) {
@@ -34,7 +35,7 @@ public class LongCondition implements Condition
                 comparator = new LongComparator() {
                     public boolean compare(Long subject)
                     {
-                        return subject == null ? false : subject.compareTo(argument) > 0;
+                        return subject == null ? false : new Double(subject).compareTo(argument) > 0;
                     }
                 };
                 break;
@@ -42,7 +43,7 @@ public class LongCondition implements Condition
                 comparator = new LongComparator() {
                     public boolean compare(Long subject)
                     {
-                        return subject == null ? false : subject.compareTo(argument) >= 0;
+                        return subject == null ? false : new Double(subject).compareTo(argument) >= 0;
                     }
                 };
                 break;
@@ -50,7 +51,7 @@ public class LongCondition implements Condition
                 comparator = new LongComparator() {
                     public boolean compare(Long subject)
                     {
-                        return subject == null ? false : subject.compareTo(argument) < 0;
+                        return subject == null ? false : new Double(subject).compareTo(argument) < 0;
                     }
                 };
                 break;
@@ -58,7 +59,7 @@ public class LongCondition implements Condition
                 comparator = new LongComparator() {
                     public boolean compare(Long subject)
                     {
-                        return subject == null ? false : subject.compareTo(argument) <= 0;
+                        return subject == null ? false : new Double(subject).compareTo(argument) <= 0;
                     }
                 };
                 break;
@@ -66,7 +67,7 @@ public class LongCondition implements Condition
                 comparator = new LongComparator() {
                     public boolean compare(Long subject)
                     {
-                        return subject == null ? true : !subject.equals(argument);
+                        return subject == null ? true : !new Double(subject).equals(argument);
                     }
                 };
                 break;
@@ -74,7 +75,7 @@ public class LongCondition implements Condition
                 comparator = new LongComparator() {
                     public boolean compare(Long subject)
                     {
-                        return subject == null ? false : subject.equals(argument);
+                        return subject == null ? false : new Double(subject).equals(argument);
                     }
                 };
                 break;

--- a/src/test/java/org/embulk/filter/row/TestDoubleCondition.java
+++ b/src/test/java/org/embulk/filter/row/TestDoubleCondition.java
@@ -30,6 +30,8 @@ public class TestDoubleCondition
         assertFalse(condition.compare(null));
         assertTrue(condition.compare(new Double(10)));
         assertFalse(condition.compare(new Double(11)));
+        assertTrue(condition.compare(new Double(10.0)));
+        assertFalse(condition.compare(new Double(11.0)));
 
         // Prohibited by Factory
         // DoubleCondition condition = new DoubleCondition("==", null, false);
@@ -42,6 +44,8 @@ public class TestDoubleCondition
         assertTrue(condition.compare(null));
         assertFalse(condition.compare(new Double(10)));
         assertTrue(condition.compare(new Double(11)));
+        assertFalse(condition.compare(new Double(10.0)));
+        assertTrue(condition.compare(new Double(11.0)));
     }
 
     @Test
@@ -51,6 +55,8 @@ public class TestDoubleCondition
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Double(10)));
         assertTrue(condition.compare(new Double(11)));
+        assertFalse(condition.compare(new Double(10.0)));
+        assertTrue(condition.compare(new Double(11.0)));
     }
 
     @Test
@@ -60,6 +66,8 @@ public class TestDoubleCondition
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Double(10)));
         assertTrue(condition.compare(new Double(11)));
+        assertFalse(condition.compare(new Double(10.0)));
+        assertTrue(condition.compare(new Double(11.0)));
     }
 
     @Test
@@ -69,6 +77,8 @@ public class TestDoubleCondition
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Double(11)));
         assertTrue(condition.compare(new Double(10)));
+        assertFalse(condition.compare(new Double(11.0)));
+        assertTrue(condition.compare(new Double(10.0)));
     }
 
     @Test
@@ -78,6 +88,8 @@ public class TestDoubleCondition
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Double(12)));
         assertTrue(condition.compare(new Double(11)));
+        assertFalse(condition.compare(new Double(12.0)));
+        assertTrue(condition.compare(new Double(11.0)));
     }
 
     @Test
@@ -87,5 +99,7 @@ public class TestDoubleCondition
         assertTrue(condition.compare(null));
         assertTrue(condition.compare(new Double(12)));
         assertFalse(condition.compare(new Double(11)));
+        assertTrue(condition.compare(new Double(12.0)));
+        assertFalse(condition.compare(new Double(11.0)));
     }
 }

--- a/src/test/java/org/embulk/filter/row/TestLongCondition.java
+++ b/src/test/java/org/embulk/filter/row/TestLongCondition.java
@@ -92,25 +92,25 @@ public class TestLongCondition
     @Test
     public void testDoubleOperatorEquals()
     {
-        LongCondition condition = new LongCondition("==", new Double(10.0), false);
+        LongCondition condition = new LongCondition("==", new Double(10.5), false);
         assertFalse(condition.compare(null));
-        assertTrue(condition.compare(new Long(10)));
+        assertFalse(condition.compare(new Long(10)));
         assertFalse(condition.compare(new Long(11)));
     }
 
     @Test
     public void testDoubleOperatorNotEquals()
     {
-        LongCondition condition = new LongCondition("!=", new Double(10.0), false);
+        LongCondition condition = new LongCondition("!=", new Double(10.5), false);
         assertTrue(condition.compare(null));
-        assertFalse(condition.compare(new Long(10)));
+        assertTrue(condition.compare(new Long(10)));
         assertTrue(condition.compare(new Long(11)));
     }
 
     @Test
     public void testDoubleOperatorGreaterThan()
     {
-        LongCondition condition = new LongCondition(">", new Double(10.0), false);
+        LongCondition condition = new LongCondition(">", new Double(10.5), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(10)));
         assertTrue(condition.compare(new Long(11)));
@@ -119,7 +119,7 @@ public class TestLongCondition
     @Test
     public void testDoubleOperatorGreaterEqual()
     {
-        LongCondition condition = new LongCondition(">=", new Double(11.0), false);
+        LongCondition condition = new LongCondition(">=", new Double(10.5), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(10)));
         assertTrue(condition.compare(new Long(11)));
@@ -128,7 +128,7 @@ public class TestLongCondition
     @Test
     public void testDoubleOperatorLessThan()
     {
-        LongCondition condition = new LongCondition("<", new Double(11.0), false);
+        LongCondition condition = new LongCondition("<", new Double(10.5), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(11)));
         assertTrue(condition.compare(new Long(10)));
@@ -137,7 +137,7 @@ public class TestLongCondition
     @Test
     public void testDoubleOperatorLessEqual()
     {
-        LongCondition condition = new LongCondition("<=", new Double(11.0), false);
+        LongCondition condition = new LongCondition("<=", new Double(11.5), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(12)));
         assertTrue(condition.compare(new Long(11)));
@@ -146,7 +146,7 @@ public class TestLongCondition
     @Test
     public void testDoubleOperatorNot()
     {
-        LongCondition condition = new LongCondition("<=", new Double(11.0), true);
+        LongCondition condition = new LongCondition("<=", new Double(11.5), true);
         assertTrue(condition.compare(null));
         assertTrue(condition.compare(new Long(12)));
         assertFalse(condition.compare(new Long(11)));

--- a/src/test/java/org/embulk/filter/row/TestLongCondition.java
+++ b/src/test/java/org/embulk/filter/row/TestLongCondition.java
@@ -26,7 +26,7 @@ public class TestLongCondition
     @Test
     public void testEquals()
     {
-        LongCondition condition = new LongCondition("==", new Long(10), false);
+        LongCondition condition = new LongCondition("==", new Double(10), false);
         assertFalse(condition.compare(null));
         assertTrue(condition.compare(new Long(10)));
         assertFalse(condition.compare(new Long(11)));
@@ -38,7 +38,7 @@ public class TestLongCondition
     @Test
     public void testNotEquals()
     {
-        LongCondition condition = new LongCondition("!=", new Long(10), false);
+        LongCondition condition = new LongCondition("!=", new Double(10), false);
         assertTrue(condition.compare(null));
         assertFalse(condition.compare(new Long(10)));
         assertTrue(condition.compare(new Long(11)));
@@ -47,7 +47,7 @@ public class TestLongCondition
     @Test
     public void testGreaterThan()
     {
-        LongCondition condition = new LongCondition(">", new Long(10), false);
+        LongCondition condition = new LongCondition(">", new Double(10), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(10)));
         assertTrue(condition.compare(new Long(11)));
@@ -56,7 +56,7 @@ public class TestLongCondition
     @Test
     public void testGreaterEqual()
     {
-        LongCondition condition = new LongCondition(">=", new Long(11), false);
+        LongCondition condition = new LongCondition(">=", new Double(11), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(10)));
         assertTrue(condition.compare(new Long(11)));
@@ -65,7 +65,7 @@ public class TestLongCondition
     @Test
     public void testLessThan()
     {
-        LongCondition condition = new LongCondition("<", new Long(11), false);
+        LongCondition condition = new LongCondition("<", new Double(11), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(11)));
         assertTrue(condition.compare(new Long(10)));
@@ -74,7 +74,7 @@ public class TestLongCondition
     @Test
     public void testLessEqual()
     {
-        LongCondition condition = new LongCondition("<=", new Long(11), false);
+        LongCondition condition = new LongCondition("<=", new Double(11), false);
         assertFalse(condition.compare(null));
         assertFalse(condition.compare(new Long(12)));
         assertTrue(condition.compare(new Long(11)));
@@ -83,7 +83,70 @@ public class TestLongCondition
     @Test
     public void testNot()
     {
-        LongCondition condition = new LongCondition("<=", new Long(11), true);
+        LongCondition condition = new LongCondition("<=", new Double(11), true);
+        assertTrue(condition.compare(null));
+        assertTrue(condition.compare(new Long(12)));
+        assertFalse(condition.compare(new Long(11)));
+    }
+
+    @Test
+    public void testDoubleOperatorEquals()
+    {
+        LongCondition condition = new LongCondition("==", new Double(10.0), false);
+        assertFalse(condition.compare(null));
+        assertTrue(condition.compare(new Long(10)));
+        assertFalse(condition.compare(new Long(11)));
+    }
+
+    @Test
+    public void testDoubleOperatorNotEquals()
+    {
+        LongCondition condition = new LongCondition("!=", new Double(10.0), false);
+        assertTrue(condition.compare(null));
+        assertFalse(condition.compare(new Long(10)));
+        assertTrue(condition.compare(new Long(11)));
+    }
+
+    @Test
+    public void testDoubleOperatorGreaterThan()
+    {
+        LongCondition condition = new LongCondition(">", new Double(10.0), false);
+        assertFalse(condition.compare(null));
+        assertFalse(condition.compare(new Long(10)));
+        assertTrue(condition.compare(new Long(11)));
+    }
+
+    @Test
+    public void testDoubleOperatorGreaterEqual()
+    {
+        LongCondition condition = new LongCondition(">=", new Double(11.0), false);
+        assertFalse(condition.compare(null));
+        assertFalse(condition.compare(new Long(10)));
+        assertTrue(condition.compare(new Long(11)));
+    }
+
+    @Test
+    public void testDoubleOperatorLessThan()
+    {
+        LongCondition condition = new LongCondition("<", new Double(11.0), false);
+        assertFalse(condition.compare(null));
+        assertFalse(condition.compare(new Long(11)));
+        assertTrue(condition.compare(new Long(10)));
+    }
+
+    @Test
+    public void testDoubleOperatorLessEqual()
+    {
+        LongCondition condition = new LongCondition("<=", new Double(11.0), false);
+        assertFalse(condition.compare(null));
+        assertFalse(condition.compare(new Long(12)));
+        assertTrue(condition.compare(new Long(11)));
+    }
+
+    @Test
+    public void testDoubleOperatorNot()
+    {
+        LongCondition condition = new LongCondition("<=", new Double(11.0), true);
         assertTrue(condition.compare(null));
         assertTrue(condition.compare(new Long(12)));
         assertFalse(condition.compare(new Long(11)));


### PR DESCRIPTION
Hello.

I want use decimal point.
## Example

``` yaml
filters:
  - type: row
    condition: AND
    conditions:
      - {column: score,   operator: ">=", argument: 0.1 }
```

Now use decimal point occurred Error(Type mismatch on column).

```
2016-05-26 13:01:57.151 +0900 [INFO] (0001:transaction): Loaded plugin embulk-input-s3 (0.2.7)
2016-05-26 13:01:58.440 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-elasticsearch_ruby (0.1.0)
2016-05-26 13:01:58.470 +0900 [INFO] (0001:transaction): Loaded plugin embulk-filter-row (0.2.0)
2016-05-26 13:01:58.586 +0900 [INFO] (0001:transaction): Loaded plugin embulk-filter-mysql (0.1.0)
2016-05-26 13:02:02.205 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4
2016-05-26 13:02:02.234 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
class java.lang.String
2016-05-26 13:02:02.632 +0900 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
org.embulk.exec.PartialExecutionException: org.embulk.config.ConfigException: RowFilterPlugin: Type mismatch on column: score
  at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(org/embulk/exec/BulkLoader.java:363)
  at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:572)
  at org.embulk.exec.BulkLoader.access$000(org/embulk/exec/BulkLoader.java:33)
  at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:374)
  at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:370)
  at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
  at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:370)
```

Thanks.
