### PR TITLE
Use joni to improve REGEXP performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     compile  "org.embulk:embulk-core:0.8.+"
     provided "org.embulk:embulk-core:0.8.+"
 
+    compile  "org.jruby.joni:joni:2.1.11"
+    compile  "org.jruby.jcodings:jcodings:1.0.18"
+
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.+:tests"
     testCompile "org.embulk:embulk-standards:0.8.+"

--- a/example/regexp_multibyte.csv
+++ b/example/regexp_multibyte.csv
@@ -1,0 +1,12 @@
+time,foo,bar,flag,id,name,json,score
+2015-07-13,,bar,true,0,ゼロ,"{\"foo\":\"bar\"}",1370
+2015-07-13,,bar,true,1,イチ,"{\"foo\":\"bar\"}",3962
+2015-07-13,,bar,true,2,ニ,"{\"foo\":\"bar\"}",7323
+2015-07-13,,bar,true,3,サン,"{\"foo\":\"bar\"}",5905
+2015-07-13,,bar,true,4,ヨン,"{\"foo\":\"bar\"}",8378
+2015-07-13,,bar,true,5,ゴ,"{\"foo\":\"bar\"}",275
+2015-07-13,,bar,true,6,ロク,"{\"foo\":\"bar\"}",43
+2015-07-13,,bar,true,7,シチ,"{\"foo\":\"bar\"}",6130
+2015-07-13,,bar,true,8,ハチ,"{\"foo\":\"bar\"}",6652
+2015-07-13,,bar,true,9,キュウ,"{\"foo\":\"bar\"}",6822
+2015-07-13,NULL,bar,false,NULL,NULL,NULL,4170

--- a/example/regexp_multibyte.yml
+++ b/example/regexp_multibyte.yml
@@ -1,0 +1,24 @@
+in:
+  type: file
+  path_prefix: example/regexp_multibyte.csv
+  parser:
+    type: csv
+    charset: UTF-8
+    newline: CRLF
+    null_string: "NULL"
+    skip_header_lines: 1
+    comment_line_marker: '#'
+    columns:
+      - {name: time,  type: timestamp, format: "%Y-%m-%d"}
+      - {name: foo,   type: string}
+      - {name: bar,   type: string}
+      - {name: flag,  type: boolean}
+      - {name: id,    type: long}
+      - {name: name,  type: string}
+      - {name: json,  type: json}
+      - {name: score, type: double}
+filters:
+  - type: row
+    where: name REGEXP '.*チ'
+out:
+  type: stdout

--- a/src/main/java/org/embulk/filter/row/where/ParserExp.java
+++ b/src/main/java/org/embulk/filter/row/where/ParserExp.java
@@ -9,6 +9,8 @@ import org.joni.Matcher;
 import org.joni.Option;
 import org.joni.Regex;
 
+import java.nio.charset.StandardCharsets;
+
 // Operation Node of AST (Abstract Syntax Tree)
 public abstract class ParserExp extends ParserNode
 {
@@ -290,7 +292,7 @@ class RegexpOpExp extends BinaryOpExp
     {
         super(left, right, operator);
 
-        byte[] pattern = (((StringLiteral)right).val).getBytes();
+        byte[] pattern = (((StringLiteral)right).val).getBytes(StandardCharsets.UTF_8);
         this.regex = new Regex(pattern, 0, pattern.length, Option.NONE, UTF8Encoding.INSTANCE);
 
         if (! left.isString()) {
@@ -305,7 +307,7 @@ class RegexpOpExp extends BinaryOpExp
 
     public boolean eval(PageReader pageReader)
     {
-        byte[] l = left.getString(pageReader).getBytes();
+        byte[] l = left.getString(pageReader).getBytes(StandardCharsets.UTF_8);
         Matcher matcher = regex.matcher(l);
         int result = matcher.search(0, l.length, Option.DEFAULT);
         return result != -1;


### PR DESCRIPTION
Using same data and same environment with http://qiita.com/sonots/items/a70482d29862de87624d, 

Before: 1m10.924s
After: 0m24.054s => 0m24.409s (with `String#getBytes("UTF-8")`)


memo ref. https://github.com/jruby/joni/issues/27
