### PR TITLE
Support new TimestampParser of embulk 0.8.29

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.8.+"
-    provided "org.embulk:embulk-core:0.8.+"
+    compile  "org.embulk:embulk-core:0.8.29+"
+    provided "org.embulk:embulk-core:0.8.29+"
 
     compile  "org.jruby.joni:joni:2.1.11"
     compile  "org.jruby.jcodings:jcodings:1.0.18"

--- a/src/main/java/org/embulk/filter/row/AbstractGuardColumnVisitor.java
+++ b/src/main/java/org/embulk/filter/row/AbstractGuardColumnVisitor.java
@@ -40,7 +40,7 @@ abstract class AbstractGuardColumnVisitor
             String columnName = conditionConfig.getColumn();
             for (Column column : outputSchema.getColumns()) {
                 if (columnName.equals(column.getName())) {
-                    ConditionFactory factory = new ConditionFactory(task.getJRuby(), column, conditionConfig);
+                    ConditionFactory factory = new ConditionFactory(column, conditionConfig);
                     Condition condition = factory.createCondition();
                     conditionMap.get(columnName).add(condition);
                     break;

--- a/src/main/java/org/embulk/filter/row/RowFilterPlugin.java
+++ b/src/main/java/org/embulk/filter/row/RowFilterPlugin.java
@@ -55,7 +55,6 @@ public class RowFilterPlugin implements FilterPlugin
             FilterPlugin.Control control)
     {
         PluginTask task = config.loadConfig(PluginTask.class);
-        ParserLiteral.setJRuby(task.getJRuby());
 
         configure(task, inputSchema);
         Schema outputSchema = inputSchema;

--- a/src/main/java/org/embulk/filter/row/condition/ConditionFactory.java
+++ b/src/main/java/org/embulk/filter/row/condition/ConditionFactory.java
@@ -15,11 +15,9 @@ import org.embulk.spi.type.StringType;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
-import org.jruby.embed.ScriptingContainer;
 
 public class ConditionFactory
 {
-    private final ScriptingContainer jruby;
     private Column column;
     private String columnName;
     private Type columnType;
@@ -27,9 +25,8 @@ public class ConditionFactory
     private String operator;
     private boolean not;
 
-    public ConditionFactory(ScriptingContainer jruby, Column column, ConditionConfig conditionConfig)
+    public ConditionFactory(Column column, ConditionConfig conditionConfig)
     {
-        this.jruby           = jruby;
         this.column          = column;
         this.columnName      = column.getName();
         this.columnType      = column.getType();
@@ -140,7 +137,7 @@ public class ConditionFactory
             String format          = (String) conditionConfig.getFormat().get();
             DateTimeZone timezone  = DateTimeZone.forID((String) conditionConfig.getTimezone().get());
 
-            TimestampParser parser = new TimestampParser(jruby, format, timezone);
+            TimestampParser parser = new TimestampParser(format, timezone);
             try {
                 Timestamp timestamp = parser.parse(argument);
                 return new TimestampCondition(operator, timestamp, not);

--- a/src/main/java/org/embulk/filter/row/where/ParserLiteral.java
+++ b/src/main/java/org/embulk/filter/row/where/ParserLiteral.java
@@ -16,19 +16,12 @@ import org.embulk.spi.type.StringType;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
-import org.jruby.embed.ScriptingContainer;
 import org.msgpack.value.Value;
 
 // Literal Node of AST (Abstract Syntax Tree)
 public abstract class ParserLiteral extends ParserNode
 {
-    protected static ScriptingContainer jruby;
     protected String yytext;
-
-    public static void setJRuby(ScriptingContainer jruby)
-    {
-        ParserLiteral.jruby = jruby;
-    }
 
     public boolean isBoolean()
     {
@@ -185,7 +178,7 @@ class TimestampLiteral extends ParserLiteral
         TimestampParseException ex = null;
         for (String format : formats) {
             try {
-                TimestampParser timestampParser = new TimestampParser(jruby, format, default_timezone);
+                TimestampParser timestampParser = new TimestampParser(format, default_timezone);
                 this.val = timestampParser.parse(literal.val);
                 break;
             }

--- a/src/test/java/org/embulk/filter/row/condition/TestConditionFactory.java
+++ b/src/test/java/org/embulk/filter/row/condition/TestConditionFactory.java
@@ -6,7 +6,6 @@ import org.embulk.config.ConfigException;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.Column;
 
-import org.jruby.embed.ScriptingContainer;
 import org.junit.Test;
 
 import static org.embulk.spi.type.Types.BOOLEAN;
@@ -63,11 +62,8 @@ public class TestConditionFactory
         }
     }
 
-    private final ScriptingContainer jruby;
-
     public TestConditionFactory()
     {
-        jruby = new ScriptingContainer();
     }
 
     @Test
@@ -83,7 +79,7 @@ public class TestConditionFactory
                 return Optional.of("IS NULL");
             }
         };
-        condition = (BooleanCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (BooleanCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(null));
 
         config = new DefaultConditionConfig() {
@@ -97,7 +93,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (BooleanCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (BooleanCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument is required");
         }
         catch (ConfigException e) {
@@ -113,7 +109,7 @@ public class TestConditionFactory
                 return Optional.of((Object) new Boolean(true));
             }
         };
-        condition = (BooleanCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (BooleanCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(new Boolean(true)));
 
         config = new DefaultConditionConfig() {
@@ -127,7 +123,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (BooleanCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (BooleanCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument type mismatch");
         }
         catch (ConfigException e) {
@@ -147,7 +143,7 @@ public class TestConditionFactory
                 return Optional.of("IS NULL");
             }
         };
-        condition = (DoubleCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (DoubleCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(null));
 
         config = new DefaultConditionConfig() {
@@ -161,7 +157,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (DoubleCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (DoubleCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument is required");
         }
         catch (ConfigException e) {
@@ -177,7 +173,7 @@ public class TestConditionFactory
                 return Optional.of((Object) new Double(10));
             }
         };
-        condition = (DoubleCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (DoubleCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(new Double(10)));
 
         config = new DefaultConditionConfig() {
@@ -191,7 +187,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (DoubleCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (DoubleCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument type mismatch");
         }
         catch (ConfigException e) {
@@ -211,7 +207,7 @@ public class TestConditionFactory
                 return Optional.of("IS NULL");
             }
         };
-        condition = (LongCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (LongCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(null));
 
         config = new DefaultConditionConfig() {
@@ -225,7 +221,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (LongCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (LongCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument is required");
         }
         catch (ConfigException e) {
@@ -241,7 +237,7 @@ public class TestConditionFactory
                 return Optional.of((Object) new Long(10));
             }
         };
-        condition = (LongCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (LongCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(new Long(10)));
 
         config = new DefaultConditionConfig() {
@@ -255,7 +251,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (LongCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (LongCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument type mismatch");
         }
         catch (ConfigException e) {
@@ -275,7 +271,7 @@ public class TestConditionFactory
                 return Optional.of("IS NULL");
             }
         };
-        condition = (StringCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (StringCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(null));
 
         config = new DefaultConditionConfig() {
@@ -289,7 +285,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (StringCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (StringCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument is required");
         }
         catch (ConfigException e) {
@@ -305,7 +301,7 @@ public class TestConditionFactory
                 return Optional.of((Object) "foo");
             }
         };
-        condition = (StringCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (StringCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare("foo"));
 
         config = new DefaultConditionConfig() {
@@ -319,7 +315,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (StringCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (StringCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument type mismatch");
         }
         catch (ConfigException e) {
@@ -339,7 +335,7 @@ public class TestConditionFactory
                 return Optional.of("IS NULL");
             }
         };
-        condition = (TimestampCondition) new ConditionFactory(jruby, column, config).createCondition();
+        condition = (TimestampCondition) new ConditionFactory(column, config).createCondition();
         assertTrue(condition.compare(null));
 
         config = new DefaultConditionConfig() {
@@ -353,19 +349,11 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (TimestampCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (TimestampCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument is required");
         }
         catch (ConfigException e) {
         }
-
-        //ToDo: How to create jruby object correctly?
-        //config = new DefaultConditionConfig() {
-        //    public Optional<String> getOperator() { return Optional.of("=="); }
-        //    public Optional<Object> getArgument() { return Optional.of((Object)"2015-07-15"); }
-        //    public Optional<String> getFormat()   { return Optional.of("%Y-%m-%d"); }
-        //};
-        //condition = (TimestampCondition)new ConditionFactory(jruby, column, config).createCondition();
 
         config = new DefaultConditionConfig() {
             public Optional<String> getOperator()
@@ -378,7 +366,7 @@ public class TestConditionFactory
             }
         };
         try {
-            condition = (TimestampCondition) new ConditionFactory(jruby, column, config).createCondition();
+            condition = (TimestampCondition) new ConditionFactory(column, config).createCondition();
             fail("Argument type mismatch");
         }
         catch (ConfigException e) {

--- a/src/test/java/org/embulk/filter/row/where/TestParser.java
+++ b/src/test/java/org/embulk/filter/row/where/TestParser.java
@@ -11,7 +11,6 @@ import org.embulk.spi.SchemaConfigException;
 import org.embulk.spi.time.Timestamp;
 
 import org.embulk.spi.time.TimestampParseException;
-import org.jruby.embed.ScriptingContainer;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,7 +31,6 @@ import static org.junit.Assert.assertTrue;
 public class TestParser
 {
     private static EmbulkTestRuntime runtime = new EmbulkTestRuntime(); // very slow
-    private static ScriptingContainer jruby = new ScriptingContainer();
 
     private static PageReader buildPageReader(Schema schema, final Object... objects)
     {
@@ -51,8 +49,6 @@ public class TestParser
     @BeforeClass
     public static void setupBeforeClass()
     {
-        ParserLiteral.setJRuby(jruby);
-
         // {"k1":{"k1":"v"},"k2":{"k2":"v"}}
         Value k1 = ValueFactory.newString("k1");
         Value k2 = ValueFactory.newString("k2");


### PR DESCRIPTION
This change follows new API of embulk 0.8.29.
This let embulk-filter-row >= 0.5.0 to require embulk >= 0.8.29.