### PR TITLE
Avoid NullPointerException

### DIFF
--- a/src/main/java/org/embulk/filter/row/where/ParserExp.java
+++ b/src/main/java/org/embulk/filter/row/where/ParserExp.java
@@ -328,6 +328,9 @@ class RegexpOpExp extends BinaryOpExp
 
     public boolean eval(PageReader pageReader)
     {
+        if (left.isNull(pageReader)) {
+            return false;
+        }
         byte[] l = left.getString(pageReader).getBytes(StandardCharsets.UTF_8);
         Matcher matcher = regex.matcher(l);
         int result = matcher.search(0, l.length, Option.DEFAULT);

--- a/src/main/java/org/embulk/filter/row/where/ParserExp.java
+++ b/src/main/java/org/embulk/filter/row/where/ParserExp.java
@@ -192,6 +192,17 @@ class TimestampOpExp extends BinaryOpExp
 
     public boolean eval(PageReader pageReader)
     {
+        boolean lIsNull = left.isIdentifier() && left.isNull(pageReader);
+        boolean rIsNull = right.isIdentifier() && right.isNull(pageReader);
+        if (lIsNull && rIsNull && operator == Parser.EQ) {
+            return true; // Both of left and right are equals as null, but it will never happen
+        }
+        else if (lIsNull != rIsNull && operator == Parser.NEQ) {
+            return true; // Either of left or right is null and both are not equals
+        }
+        else if (lIsNull || rIsNull) {
+            return false; // Can't be evaluated by any other operator if either of left or right is null
+        }
         Instant l = left.getTimestamp(pageReader);
         Instant r = right.getTimestamp(pageReader);
         if (operator == Parser.EQ) {
@@ -247,6 +258,17 @@ class StringOpExp extends BinaryOpExp
 
     public boolean eval(PageReader pageReader)
     {
+        boolean lIsNull = left.isIdentifier() && left.isNull(pageReader);
+        boolean rIsNull = right.isIdentifier() && right.isNull(pageReader);
+        if (lIsNull && rIsNull && operator == Parser.EQ) {
+            return true; // Both of left and right are equals as null, but it will never happen
+        }
+        else if (lIsNull != rIsNull && operator == Parser.NEQ) {
+            return true; // Either of left or right is null and both are not equals
+        }
+        else if (lIsNull || rIsNull) {
+            return false; // Can't be evaluated by any other operator if either of left or right is null
+        }
         String l = left.getString(pageReader);
         String r = right.getString(pageReader);
         if (operator == Parser.EQ) {

--- a/src/test/java/org/embulk/filter/row/where/TestParser.java
+++ b/src/test/java/org/embulk/filter/row/where/TestParser.java
@@ -425,6 +425,9 @@ public class TestParser
         exp = parser.parse("string REGEXP 'st$'");
         assertFalse(exp.eval(reader));
 
+        exp = parser.parse("null_string REGEXP '^st'");
+        assertFalse(exp.eval(reader));
+
         try {
             // right-side identifier is not allowed
             parser.parse("'string' REGEXP string");

--- a/src/test/java/org/embulk/filter/row/where/TestParser.java
+++ b/src/test/java/org/embulk/filter/row/where/TestParser.java
@@ -61,6 +61,8 @@ public class TestParser
                 .add("long", LONG)
                 .add("double", DOUBLE)
                 .add("true", BOOLEAN)
+                .add("null_timestamp", TIMESTAMP)
+                .add("null_string", STRING)
                 .add("null", BOOLEAN)
                 .add("json", JSON)
                 .build();
@@ -72,6 +74,8 @@ public class TestParser
                 1L,
                 1.5,
                 true,
+                null,
+                null,
                 null,
                 map
                 );
@@ -88,6 +92,31 @@ public class TestParser
 
         exp = parser.parse("\"true\" = true");
         assertTrue(exp.eval(reader));
+
+        exp = parser.parse("null_timestamp IS NULL");
+        assertTrue(exp.eval(reader));
+        exp = parser.parse("null_timestamp IS NOT NULL");
+        assertFalse(exp.eval(reader));
+        exp = parser.parse("null_timestamp = TIMESTAMP '1970-01-01 09:00:01.5 +0900'");
+        assertFalse(exp.eval(reader));
+        exp = parser.parse("null_timestamp != TIMESTAMP '1970-01-01 09:00:01.5 +0900'");
+        assertTrue(exp.eval(reader));
+
+        exp = parser.parse("null_string IS NULL");
+        assertTrue(exp.eval(reader));
+        exp = parser.parse("null_string IS NOT NULL");
+        assertFalse(exp.eval(reader));
+        exp = parser.parse("null_string = 'string'");
+        assertFalse(exp.eval(reader));
+        exp = parser.parse("null_string != 'string'");
+        assertTrue(exp.eval(reader));
+
+        try {
+            parser.parse("null_timestamp = null_string"); // Both of left and right are an identifier
+            assertTrue(false);
+        }
+        catch (ConfigException e) {
+        }
 
         try {
             parser.parse("\"unknown\" IS NULL");


### PR DESCRIPTION
## Problems

With the following config and csv

<details>
<summary>config</summary>

```
$ cat config.yml
in:
  type: file
  path_prefix: in.csv
  parser:
    type: csv
    skip_header_lines: 1
    columns:
    - {name: timestamp, type: timestamp}
    - {name: string, type: string}
filters:
- type: row
  where: timestamp = '1970-01-01 09:00:01.5 +0900' OR string = 'string'
out:
  type: stdout
```

</details>
<details>
<summary>csv</summary>

```
$ cat in.csv
timestamp,string
1970-01-01 09:00:01.5 +0900,string
```

</details>

This preview will be successful

<details>
<summary>preview</summary>

```
$ embulk preview config.yml --log-level error
2022-10-12 13:07:15.670 +0900: Embulk v0.9.26
+-----------------------------+---------------+
|         timestamp:timestamp | string:string |
+-----------------------------+---------------+
| 1970-01-01 00:00:01.500 UTC |        string |
+-----------------------------+---------------+
```

</details>

However, for the following csv

<details>
<summary>csv</summary>

```
$ cat in.csv
timestamp,string
,string
```

</details>

This preview will be failed at TimestampOpExp#eval

<details>
<summary>preview</summary>

```
$ embulk preview config.yml --log-level error
2022-10-12 13:07:54.900 +0900: Embulk v0.9.26
java.lang.NullPointerException
	at org.embulk.filter.row.where.IdentifierLiteral.getTimestamp(ParserLiteral.java:299)
	at org.embulk.filter.row.where.TimestampOpExp.eval(ParserExp.java:195)
	at org.embulk.filter.row.where.LogicalOpExp.eval(ParserExp.java:368)
	at org.embulk.filter.row.GuardColumnVisitorWhereImpl.visitColumns(GuardColumnVisitorWhereImpl.java:24)
	at org.embulk.filter.row.RowFilterPlugin$1.add(RowFilterPlugin.java:169)
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:214)
	at org.embulk.spi.PageBuilder.finish(PageBuilder.java:226)
	at org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:388)
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:140)
	at org.embulk.exec.PreviewExecutor$2$1.run(PreviewExecutor.java:122)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:84)
	at org.embulk.spi.util.Filters$RecursiveControl$1.run(Filters.java:80)
	at org.embulk.filter.row.RowFilterPlugin.transaction(RowFilterPlugin.java:97)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:76)
	at org.embulk.spi.util.Filters.transaction(Filters.java:42)
	at org.embulk.exec.PreviewExecutor$2.run(PreviewExecutor.java:112)
	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:112)
	at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:237)
	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:107)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:68)
	at org.embulk.spi.util.Decoders.transaction(Decoders.java:29)
	at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:105)
	at org.embulk.exec.BufferFileInputPlugin.transaction(BufferFileInputPlugin.java:21)
	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:62)
	at org.embulk.exec.PreviewExecutor.doPreview(PreviewExecutor.java:110)
	at org.embulk.exec.PreviewExecutor.doPreview(PreviewExecutor.java:96)
	at org.embulk.exec.PreviewExecutor.access$000(PreviewExecutor.java:28)
	at org.embulk.exec.PreviewExecutor$1.run(PreviewExecutor.java:65)
	at org.embulk.exec.PreviewExecutor$1.run(PreviewExecutor.java:62)
	at org.embulk.spi.Exec.doWith(Exec.java:22)
	at org.embulk.exec.PreviewExecutor.preview(PreviewExecutor.java:62)
	at org.embulk.EmbulkEmbed.preview(EmbulkEmbed.java:231)
	at org.embulk.EmbulkRunner.previewInternal(EmbulkRunner.java:213)
	at org.embulk.EmbulkRunner.preview(EmbulkRunner.java:106)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:428)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
	at org.embulk.cli.Main.main(Main.java:64)

Error: null
```

</details>

Likewise, for the following csv

<details>
<summary>csv</summary>

```
$ cat in.csv
timestamp,string
1970-01-01 09:00:01.5 +0900,
```

</details>

This preview will be failed as well at StringOpExp#eval

<details>
<summary>preview</summary>

```
$ embulk preview config.yml --log-level error
2022-10-12 13:09:12.026 +0900: Embulk v0.9.26
java.lang.NullPointerException
	at org.embulk.filter.row.where.StringOpExp.eval(ParserExp.java:253)
	at org.embulk.filter.row.where.LogicalOpExp.eval(ParserExp.java:369)
	at org.embulk.filter.row.GuardColumnVisitorWhereImpl.visitColumns(GuardColumnVisitorWhereImpl.java:24)
	at org.embulk.filter.row.RowFilterPlugin$1.add(RowFilterPlugin.java:169)
	at org.embulk.spi.PageBuilder.doFlush(PageBuilder.java:214)
	at org.embulk.spi.PageBuilder.finish(PageBuilder.java:226)
	at org.embulk.standards.CsvParserPlugin.run(CsvParserPlugin.java:388)
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:140)
	at org.embulk.exec.PreviewExecutor$2$1.run(PreviewExecutor.java:122)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:84)
	at org.embulk.spi.util.Filters$RecursiveControl$1.run(Filters.java:80)
	at org.embulk.filter.row.RowFilterPlugin.transaction(RowFilterPlugin.java:97)
	at org.embulk.spi.util.Filters$RecursiveControl.transaction(Filters.java:76)
	at org.embulk.spi.util.Filters.transaction(Filters.java:42)
	at org.embulk.exec.PreviewExecutor$2.run(PreviewExecutor.java:112)
	at org.embulk.spi.FileInputRunner$RunnerControl$1$1.run(FileInputRunner.java:112)
	at org.embulk.standards.CsvParserPlugin.transaction(CsvParserPlugin.java:237)
	at org.embulk.spi.FileInputRunner$RunnerControl$1.run(FileInputRunner.java:107)
	at org.embulk.spi.util.Decoders$RecursiveControl.transaction(Decoders.java:68)
	at org.embulk.spi.util.Decoders.transaction(Decoders.java:29)
	at org.embulk.spi.FileInputRunner$RunnerControl.run(FileInputRunner.java:105)
	at org.embulk.exec.BufferFileInputPlugin.transaction(BufferFileInputPlugin.java:21)
	at org.embulk.spi.FileInputRunner.transaction(FileInputRunner.java:62)
	at org.embulk.exec.PreviewExecutor.doPreview(PreviewExecutor.java:110)
	at org.embulk.exec.PreviewExecutor.doPreview(PreviewExecutor.java:96)
	at org.embulk.exec.PreviewExecutor.access$000(PreviewExecutor.java:28)
	at org.embulk.exec.PreviewExecutor$1.run(PreviewExecutor.java:65)
	at org.embulk.exec.PreviewExecutor$1.run(PreviewExecutor.java:62)
	at org.embulk.spi.Exec.doWith(Exec.java:22)
	at org.embulk.exec.PreviewExecutor.preview(PreviewExecutor.java:62)
	at org.embulk.EmbulkEmbed.preview(EmbulkEmbed.java:231)
	at org.embulk.EmbulkRunner.previewInternal(EmbulkRunner.java:213)
	at org.embulk.EmbulkRunner.preview(EmbulkRunner.java:106)
	at org.embulk.cli.EmbulkRun.runSubcommand(EmbulkRun.java:428)
	at org.embulk.cli.EmbulkRun.run(EmbulkRun.java:90)
	at org.embulk.cli.Main.main(Main.java:64)

Error: null
```

</details>

## Modifications

Added null value's identifiers handling for TimestampOpExp#eval and StringOpExp#eval

## Confirmations

With the following csv

<details>
<summary>csv</summary>

```
$ cat in.csv
timestamp,string
1970-01-01 09:00:01.5 +0900,string
,string
1970-01-01 09:00:01.5 +0900,
```

</details>

As expected, NullPointerException will no longer occurs

<details>
<summary>preview</summary>

```
$ embulk preview config.yml --log-level error
2022-10-12 13:11:38.243 +0900: Embulk v0.9.26
+-----------------------------+---------------+
|         timestamp:timestamp | string:string |
+-----------------------------+---------------+
| 1970-01-01 00:00:01.500 UTC |        string |
|                             |        string |
| 1970-01-01 00:00:01.500 UTC |               |
+-----------------------------+---------------+
```

</details>